### PR TITLE
Removing staged versions for MAPpoly and QTLpoly

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17,8 +17,7 @@
     },
     {
         "package": "MAPpoly",
-        "url": "https://github.com/mmollina/MAPpoly",
-        "branch": "release"
+        "url": "https://github.com/mmollina/MAPpoly"
     },
     {
         "package": "polymapR",
@@ -34,8 +33,7 @@
     },
     {
         "package": "QTLpoly",
-        "url": "https://github.com/gabrielgesteira/QTLpoly",
-        "branch": "release"
+        "url": "https://github.com/gabrielgesteira/QTLpoly"
     },
     {
         "package": "updog",


### PR DESCRIPTION
It seems the build script doesn't recognize the release versions, so skipping this for now (this PR removes only the last item of #1)