### PR TITLE
Fixing typo in package names

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/jendelman/polyBreedR"
     },
     {
-        "package": "MAPpoly",
+        "package": "mappoly",
         "url": "https://github.com/mmollina/MAPpoly"
     },
     {
@@ -32,7 +32,7 @@
         "url": "https://github.com/lvclark/polyRAD"
     },
     {
-        "package": "QTLpoly",
+        "package": "qtlpoly",
         "url": "https://github.com/gabrielgesteira/QTLpoly"
     },
     {


### PR DESCRIPTION
This fixes a typo in two package names (MAPpoly and QTLpoly).